### PR TITLE
Admin permissions endpoint

### DIFF
--- a/Luxury Wear.postman_collection.json
+++ b/Luxury Wear.postman_collection.json
@@ -1,11 +1,11 @@
 {
 	"info": {
-		"_postman_id": "2152dfca-5896-454e-9e6f-ea3dd3ec2185",
+		"_postman_id": "4bce38b5-5e0e-4bfe-a64b-342469745acd",
 		"name": "Luxury Wear",
 		"description": "The available endpoints in the **Luxury Wear Service** API and their respective functionalities.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "31370436",
-		"_collection_link": "https://backend-9752.postman.co/workspace/backend-Workspace~81436d71-bfab-4f69-80c6-0fe7a676020f/collection/31370436-2152dfca-5896-454e-9e6f-ea3dd3ec2185?action=share&source=collection_link&creator=31370436"
+		"_collection_link": "https://backend-9752.postman.co/workspace/backend-Workspace~81436d71-bfab-4f69-80c6-0fe7a676020f/collection/31370436-4bce38b5-5e0e-4bfe-a64b-342469745acd?action=share&source=collection_link&creator=31370436"
 	},
 	"item": [
 		{
@@ -2366,84 +2366,6 @@
 					},
 					"response": [
 						{
-							"name": "OK",
-							"originalRequest": {
-								"method": "DELETE",
-								"header": [],
-								"url": {
-									"raw": "{{baseUrl}}/api/v1/users/delete-user/:id",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"users",
-										"delete-user",
-										":id"
-									],
-									"variable": [
-										{
-											"key": "id",
-											"value": "2",
-											"description": "(Required) ID of the product"
-										}
-									]
-								}
-							},
-							"status": "No Content",
-							"code": 204,
-							"_postman_previewlanguage": "plain",
-							"header": [
-								{
-									"key": "Vary",
-									"value": "Origin"
-								},
-								{
-									"key": "Vary",
-									"value": "Access-Control-Request-Method"
-								},
-								{
-									"key": "Vary",
-									"value": "Access-Control-Request-Headers"
-								},
-								{
-									"key": "X-Content-Type-Options",
-									"value": "nosniff"
-								},
-								{
-									"key": "X-XSS-Protection",
-									"value": "0"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-cache, no-store, max-age=0, must-revalidate"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Expires",
-									"value": "0"
-								},
-								{
-									"key": "Date",
-									"value": "Mon, 04 Nov 2024 19:12:19 GMT"
-								},
-								{
-									"key": "Keep-Alive",
-									"value": "timeout=60"
-								},
-								{
-									"key": "Connection",
-									"value": "keep-alive"
-								}
-							],
-							"cookie": [],
-							"body": ""
-						},
-						{
 							"name": "Not found",
 							"originalRequest": {
 								"method": "DELETE",
@@ -2528,6 +2450,92 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"timestamp\": \"2024-11-04T14:12:27.673911507\",\n    \"message\": \"User not found with Id: 2\",\n    \"details\": \"/api/v1/users/delete-user/2\"\n}"
+						},
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/delete-user/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"delete-user",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "2",
+											"description": "(Required) ID of the product"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Vary",
+									"value": "Origin"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Method"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Headers"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-cache, no-store, max-age=0, must-revalidate"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Expires",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 07 Nov 2024 01:01:06 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"message\": \"User deleted successfully\",\n    \"userId\": \"2\"\n}"
 						}
 					]
 				},

--- a/Luxury Wear.postman_collection.json
+++ b/Luxury Wear.postman_collection.json
@@ -3120,6 +3120,260 @@
 							"body": "{\n    \"timestamp\": \"2024-11-04T14:34:50.105921303\",\n    \"message\": \"User not found with email: tineoasjf@mail.com\",\n    \"details\": \"/api/v1/users/email\"\n}"
 						}
 					]
+				},
+				{
+					"name": "Set Admin permission",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTczMDk0MjI1NCwiZXhwIjoxNzMwOTQyMzc0fQ.cB0rPvkh07a-_YNwUJO9XCpGsY2zRNpjWraTNDJv0g8fToceaoTT3UDhKeO4BRMMaVmWnql9RqA0fnyoJqaVtA",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\": \"david@blanco.com\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/users/set-admin",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"set-admin"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"email\": \"david@blanco.com\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/set-admin",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"set-admin"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Vary",
+									"value": "Origin"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Method"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Headers"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-cache, no-store, max-age=0, must-revalidate"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Expires",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 07 Nov 2024 01:12:50 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"message\": \"User is now an admin\",\n    \"email\": \"david@blanco.com\"\n}"
+						}
+					]
+				},
+				{
+					"name": "Remove Admin permission",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTczMDk0MjI1NCwiZXhwIjoxNzMwOTQyMzc0fQ.cB0rPvkh07a-_YNwUJO9XCpGsY2zRNpjWraTNDJv0g8fToceaoTT3UDhKeO4BRMMaVmWnql9RqA0fnyoJqaVtA",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\": \"david@blanco.com\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/users/remove-admin",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"remove-admin"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "OK",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"email\": \"david@blanco.com\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/users/remove-admin",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"users",
+										"remove-admin"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Vary",
+									"value": "Origin"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Method"
+								},
+								{
+									"key": "Vary",
+									"value": "Access-Control-Request-Headers"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-cache, no-store, max-age=0, must-revalidate"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Expires",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 07 Nov 2024 01:13:41 GMT"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=60"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"message\": \"User is no longer an admin\",\n    \"email\": \"david@blanco.com\"\n}"
+						}
+					]
 				}
 			]
 		}

--- a/src/main/java/com/luxury/wear/service/controller/UserController.java
+++ b/src/main/java/com/luxury/wear/service/controller/UserController.java
@@ -56,4 +56,10 @@ public class UserController {
         User existingUser = userService.findByEmail(email.getEmail());
         return ResponseEntity.status(HttpStatus.OK).body(existingUser);
     }
+
+    @PutMapping("/set-admin")
+    public ResponseEntity<String> setAdmin(@RequestBody EmailRequest email) {
+        userService.setAdmin(email.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).body("User with email: " + email.getEmail() + " is now an admin");
+    }
 }

--- a/src/main/java/com/luxury/wear/service/controller/UserController.java
+++ b/src/main/java/com/luxury/wear/service/controller/UserController.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -46,10 +48,14 @@ public class UserController {
     }
 
     @DeleteMapping("/delete-user/{id}")
-    public ResponseEntity<String> deleteUser(@PathVariable("id") Long id) {
+    public ResponseEntity<Map<String, String>> deleteUser(@PathVariable("id") Long id) {
         userService.deleteUserById(id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "User deleted successfully");
+        response.put("userId", id.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
 
     @GetMapping("/email")
     public ResponseEntity<User> getUserByEmail(@RequestBody EmailRequest email) {
@@ -58,14 +64,21 @@ public class UserController {
     }
 
     @PutMapping("/set-admin")
-    public ResponseEntity<String> setAdmin(@RequestBody EmailRequest email) {
+    public ResponseEntity<Map<String, String>> setAdmin(@RequestBody EmailRequest email) {
         userService.setAdmin(email.getEmail());
-        return ResponseEntity.status(HttpStatus.OK).body("User with email: " + email.getEmail() + " is now an admin");
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "User is now an admin");
+        response.put("email", email.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @PutMapping("/remove-admin")
-    public ResponseEntity<String> removeAdmin(@RequestBody EmailRequest email) {
+    public ResponseEntity<Map<String, String>> removeAdmin(@RequestBody EmailRequest email) {
         userService.removeAdmin(email.getEmail());
-        return ResponseEntity.status(HttpStatus.OK).body("User with email: " + email.getEmail() + " is no longer an admin");
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "User is no longer an admin");
+        response.put("email", email.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
 }

--- a/src/main/java/com/luxury/wear/service/controller/UserController.java
+++ b/src/main/java/com/luxury/wear/service/controller/UserController.java
@@ -62,4 +62,10 @@ public class UserController {
         userService.setAdmin(email.getEmail());
         return ResponseEntity.status(HttpStatus.OK).body("User with email: " + email.getEmail() + " is now an admin");
     }
+
+    @PutMapping("/remove-admin")
+    public ResponseEntity<String> removeAdmin(@RequestBody EmailRequest email) {
+        userService.removeAdmin(email.getEmail());
+        return ResponseEntity.status(HttpStatus.OK).body("User with email: " + email.getEmail() + " is no longer an admin");
+    }
 }

--- a/src/main/java/com/luxury/wear/service/security/SecurityConfig.java
+++ b/src/main/java/com/luxury/wear/service/security/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/users/delete-user/{id}").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/page/{page}", "/api/v1/users").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/users").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/set-admin", "/api/v1/users/remove-admin").hasRole("ADMIN")
 
                         // All other requests
                         .anyRequest().authenticated()

--- a/src/main/java/com/luxury/wear/service/service/user/UserService.java
+++ b/src/main/java/com/luxury/wear/service/service/user/UserService.java
@@ -19,6 +19,8 @@ public interface UserService {
 
     void setAdmin(String email);
 
+    void removeAdmin(String email);
+
     void deleteUserById(Long id);
 
     User findByEmail(String email);

--- a/src/main/java/com/luxury/wear/service/service/user/UserService.java
+++ b/src/main/java/com/luxury/wear/service/service/user/UserService.java
@@ -17,6 +17,8 @@ public interface UserService {
 
     User updateUser(User user);
 
+    void setAdmin(String email);
+
     void deleteUserById(Long id);
 
     User findByEmail(String email);

--- a/src/main/java/com/luxury/wear/service/service/user/UserServiceImpl.java
+++ b/src/main/java/com/luxury/wear/service/service/user/UserServiceImpl.java
@@ -95,4 +95,12 @@ public class UserServiceImpl implements UserService {
         existingUser.setUserRole(UserRole.ADMIN);
         userRepository.save(existingUser);
     }
+
+    @Override
+    public void removeAdmin(String email) {
+        User existingUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND_EMAIL + email));
+        existingUser.setUserRole(UserRole.USER);
+        userRepository.save(existingUser);
+    }
 }

--- a/src/main/java/com/luxury/wear/service/service/user/UserServiceImpl.java
+++ b/src/main/java/com/luxury/wear/service/service/user/UserServiceImpl.java
@@ -87,4 +87,12 @@ public class UserServiceImpl implements UserService {
 
         return userRepository.save(existingUser);
     }
+
+    @Override
+    public void setAdmin(String email) {
+        User existingUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND_EMAIL + email));
+        existingUser.setUserRole(UserRole.ADMIN);
+        userRepository.save(existingUser);
+    }
 }


### PR DESCRIPTION
# Pull Request Summary
This PR introduces and enhances admin permission management within the UserController. Key changes include:

1. feat: Implemented endpoints for assigning and removing admin permissions.
2. /set-admin and /remove-admin endpoints allow admin role assignment and revocation.
3. feat: Restricted access to the set-admin and remove-admin endpoints to users with the ADMIN role, ensuring secure role management.
4. fix: Updated response format for endpoints in UserController to return JSON using a HashMap for improved clarity and consistency.
5. Merged the latest updates from main to keep the feature branch (admin-permissions-endpoint) aligned with the base branch.